### PR TITLE
Add optional chaining plugin

### DIFF
--- a/gorosend-lib/babel.config.js
+++ b/gorosend-lib/babel.config.js
@@ -9,4 +9,7 @@ module.exports = {
       },
     ],
   ],
+  plugins: [
+    '@babel/plugin-proposal-optional-chaining',
+  ],
 };

--- a/gorosend-lib/package.json
+++ b/gorosend-lib/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.6.0",
+    "@babel/plugin-proposal-optional-chaining": "^7.21.0",
     "@babel/preset-env": "^7.6.0",
     "babel-jest": "^24.9.0",
     "eslint": "^7.25.0",


### PR DESCRIPTION
## Summary
- add '@babel/plugin-proposal-optional-chaining' to Babel config
- list optional chaining plugin in gorosend-lib dev dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68695bdad2e48333bbf640ce0e298448