### PR TITLE
Refactor any usages

### DIFF
--- a/src/components/admin/ChannelManagement.tsx
+++ b/src/components/admin/ChannelManagement.tsx
@@ -88,8 +88,16 @@ export const ChannelManagement: React.FC = () => {
       }
 
       // Подготавливаем данные для вставки
-      const channelInsertData: any = {
+      interface ChannelInsertPayload {
+        name: string;
+        username: string;
+        chat_id: string | null;
+        invite_link: string | null;
+      }
+
+      const channelInsertData: ChannelInsertPayload = {
         name: data.name,
+        username: '',
         chat_id: data.chat_id.trim() || null,
         invite_link: data.invite_link.trim() || null,
       };
@@ -165,7 +173,14 @@ export const ChannelManagement: React.FC = () => {
 
   const updateChannelMutation = useMutation({
     mutationFn: async ({ id, data }: { id: string; data: Partial<ChannelFormData> }) => {
-      const channelUpdateData: { [key: string]: any } = {};
+      interface ChannelUpdatePayload {
+        name?: string;
+        username?: string;
+        chat_id?: string | null;
+        invite_link?: string | null;
+      }
+
+      const channelUpdateData: ChannelUpdatePayload = {};
       if (data.name !== undefined) channelUpdateData.name = data.name;
       if (data.username !== undefined) channelUpdateData.username = data.username || '';
       if (data.chat_id !== undefined) channelUpdateData.chat_id = data.chat_id || null;
@@ -179,7 +194,12 @@ export const ChannelManagement: React.FC = () => {
         if (channelError) throw channelError;
       }
 
-      const appChannelUpdateData: { [key: string]: any } = {};
+      interface AppChannelUpdatePayload {
+        required?: boolean;
+        app?: string;
+      }
+
+      const appChannelUpdateData: AppChannelUpdatePayload = {};
       if (data.required !== undefined) appChannelUpdateData.required = data.required;
       if (data.app_name && data.app_name !== 'both') appChannelUpdateData.app = data.app_name;
 

--- a/src/components/admin/ManualDruidSignsEditor.tsx
+++ b/src/components/admin/ManualDruidSignsEditor.tsx
@@ -7,6 +7,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/hooks/use-toast";
 import { Loader2 } from "lucide-react";
 import type { Database } from "@/integrations/supabase/types";
+import type { PostgrestError } from '@supabase/supabase-js';
 import { QuillEditor } from "./QuillEditor";
 
 // Типизация по схеме Supabase
@@ -27,7 +28,10 @@ export const ManualDruidSignsEditor: React.FC = () => {
     const fetchTexts = async () => {
       const { data, error } = await supabase
         .from("druid_sign_texts")
-        .select("sign_id,text") as { data: Array<Pick<DruidSignTextRow, "sign_id" | "text">> | null, error: any };
+        .select("sign_id,text") as {
+          data: Array<Pick<DruidSignTextRow, "sign_id" | "text">> | null;
+          error: PostgrestError | null;
+        };
       if (error) {
         toast({
           title: "Ошибка загрузки описаний",
@@ -75,7 +79,7 @@ export const ManualDruidSignsEditor: React.FC = () => {
           description: `Описание для "${DRUID_SIGNS.find(s => s.id === sign_id)?.name || sign_id}" сохранено.`,
         });
       }
-    } catch (e: any) {
+    } catch (e: unknown) {
       toast({
         title: `Ошибка сохранения`,
         description: String(e),

--- a/src/components/admin/SimulateSubscriptionCheck.tsx
+++ b/src/components/admin/SimulateSubscriptionCheck.tsx
@@ -9,7 +9,7 @@ import { LoadingSpinner } from "@/components/LoadingSpinner";
 export const SimulateSubscriptionCheck: React.FC = () => {
   const [userInput, setUserInput] = useState("");
   const [appCode, setAppCode] = useState("druid");
-  const [result, setResult] = useState<any>(null);
+  const [result, setResult] = useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
@@ -62,8 +62,9 @@ export const SimulateSubscriptionCheck: React.FC = () => {
         ...data,
         status: resp.status,
       });
-    } catch (err: any) {
-      setErrorMsg(err.message || "Неизвестная ошибка");
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Неизвестная ошибка";
+      setErrorMsg(msg);
     }
     setLoading(false);
   };

--- a/src/components/admin/SystemLogs.tsx
+++ b/src/components/admin/SystemLogs.tsx
@@ -16,7 +16,7 @@ interface SystemLog {
   id: string;
   level: string;
   message: string;
-  context: any;
+  context: Record<string, unknown> | null;
   function_name: string;
   user_id: string;
   created_at: string;

--- a/src/components/admin/UploadDruidTextsPDF.tsx
+++ b/src/components/admin/UploadDruidTextsPDF.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { DRUID_SIGNS } from "@/utils/druid-signs";
 // Импорт API pdf.js для браузера актуальной версией
-import { getDocument, GlobalWorkerOptions } from "pdfjs-dist";
+import { getDocument, GlobalWorkerOptions, type PDFDocumentProxy, type TextItem } from "pdfjs-dist";
 
 // Настраиваем workerSrc строкой для браузера и Vite
 GlobalWorkerOptions.workerSrc = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.10.38/pdf.worker.min.js";
@@ -48,13 +48,15 @@ export const UploadDruidTextsPDF: React.FC = () => {
   async function extractPDFText(file: File): Promise<string> {
     const typedarray = new Uint8Array(await file.arrayBuffer());
     // Получаем pdf-документ через getDocument
-    const pdf = await getDocument({ data: typedarray }).promise as any;
+    const pdf: PDFDocumentProxy = await getDocument({ data: typedarray }).promise;
     let fullText = "";
 
     for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
       const page = await pdf.getPage(pageNum);
       const content = await page.getTextContent();
-      const pageText = content.items.map((item: any) => item.str).join(" ");
+      const pageText = content.items
+        .map((item) => (item as TextItem).str)
+        .join(" ");
       fullText += pageText + "\n";
     }
     return fullText;

--- a/src/hooks/useAdminLogs.ts
+++ b/src/hooks/useAdminLogs.ts
@@ -5,11 +5,11 @@ import { supabase } from '@/integrations/supabase/client';
 interface AdminLogData {
   log_type: string;
   operation: string;
-  details?: Record<string, any>;
+  details?: Record<string, unknown>;
   user_count?: number;
   filtered_count?: number;
   telegram_user_id?: number;
-  session_info?: Record<string, any>;
+  session_info?: Record<string, unknown>;
   request_url?: string;
   user_agent?: string;
   ip_address?: string;
@@ -22,7 +22,7 @@ interface SecurityEventData {
   event_type: string;
   severity?: 'low' | 'medium' | 'high' | 'critical';
   description: string;
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
   telegram_user_id?: number;
   blocked_action?: string;
 }

--- a/src/hooks/useCookieSubscriptionVerification.ts
+++ b/src/hooks/useCookieSubscriptionVerification.ts
@@ -75,8 +75,8 @@ export const useCookieSubscriptionVerification = (webApp: TelegramWebApp | null)
       setResult(finalResult);
       return finalResult;
 
-    } catch (err: any) {
-      const errorMessage = err.message || 'Ошибка проверки подписок';
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : 'Ошибка проверки подписок';
       console.error('Ошибка при проверке подписок cookie:', err);
       setError(errorMessage);
       return null;

--- a/src/hooks/useSubscriptionVerification.ts
+++ b/src/hooks/useSubscriptionVerification.ts
@@ -75,8 +75,8 @@ export const useSubscriptionVerification = (webApp: TelegramWebApp | null) => {
       setResult(finalResult);
       return finalResult;
 
-    } catch (err: any) {
-      const errorMessage = err.message || 'Ошибка проверки подписок';
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : 'Ошибка проверки подписок';
       console.error('Ошибка при проверке подписок:', err);
       setError(errorMessage);
       return null;

--- a/src/hooks/useTelegramWebApp.ts
+++ b/src/hooks/useTelegramWebApp.ts
@@ -57,7 +57,10 @@ export const useTelegramWebApp = () => {
             };
 
             try {
-              const onEvent = (tg as any)?.onEvent;
+              interface WebAppWithEvent extends TelegramWebApp {
+                onEvent?: (event: string, cb: () => void) => void;
+              }
+              const onEvent = (tg as WebAppWithEvent | null)?.onEvent;
               if (typeof onEvent === 'function') {
                 onEvent.call(tg, 'visibility_changed', handleVisibilityChange);
               }

--- a/src/hooks/useUserSubscriptions.ts
+++ b/src/hooks/useUserSubscriptions.ts
@@ -4,13 +4,28 @@ import { supabase } from '@/integrations/supabase/client';
 import { useTelegramContext } from '@/components/TelegramProvider';
 import type { Channel } from './useChannels';
 
+interface DebugInfo {
+  user: ReturnType<typeof useTelegramContext>['user'];
+  step: string;
+  appCode: string;
+  times: Record<string, number>;
+  appChannelsRaw: unknown;
+  channels: Channel[] | null;
+  channelIdentifiers: string[] | null;
+  checkResult: unknown;
+  missingChannels: Channel[] | null;
+  thrownError: unknown;
+  checkError?: unknown;
+  subscriptionsById?: Record<string, boolean>;
+}
+
 interface SubscriptionResult {
   hasUnsubscribedChannels: boolean;
   missingChannels: Channel[];
   subscriptionsById: Record<string, boolean>;
   isLoading: boolean;
   error: string | null;
-  debugInfo?: any;
+  debugInfo?: DebugInfo;
 }
 
 export function useUserSubscriptions(appCode: 'druid' | 'cookie' = 'druid') {
@@ -27,7 +42,7 @@ export function useUserSubscriptions(appCode: 'druid' | 'cookie' = 'druid') {
         throw new Error('Пользователь не аутентифицирован');
       }
 
-      const debugInfo: any = {
+      const debugInfo: DebugInfo = {
         user,
         step: 'start',
         appCode,

--- a/src/pages/GorosendPage.tsx
+++ b/src/pages/GorosendPage.tsx
@@ -17,6 +17,13 @@ interface PlanetPosition {
   degree: number;
 }
 
+interface PlanetFromLib {
+  label?: string;
+  key?: string;
+  ChartPosition?: { Ecliptic?: { DecimalDegrees?: number } };
+  Sign?: { label?: string; key?: string };
+}
+
 const GorosendPage: React.FC = () => {
   const [birthDate, setBirthDate] = useState('');
   const [birthTime, setBirthTime] = useState('');
@@ -107,7 +114,7 @@ const GorosendPage: React.FC = () => {
       }
       
       // Формируем данные для отображения
-      const planetData: PlanetPosition[] = planetsList.map((planet: any) => {
+      const planetData: PlanetPosition[] = planetsList.map((planet: PlanetFromLib) => {
         console.log('Обрабатываем планету:', planet);
         
         const degrees = planet.ChartPosition?.Ecliptic?.DecimalDegrees || 0;
@@ -125,12 +132,14 @@ const GorosendPage: React.FC = () => {
       console.log('Сформированные данные планет:', planetData);
       setPlanetPositions(planetData);
       
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('=== ОШИБКА ПРИ РАСЧЕТЕ ГОРОСКОПА ===');
       console.error('Тип ошибки:', typeof error);
-      console.error('Сообщение ошибки:', error.message);
+      console.error('Сообщение ошибки:', error instanceof Error ? error.message : 'unknown');
       console.error('Полная ошибка:', error);
-      console.error('Stack trace:', error.stack);
+      if (error instanceof Error) {
+        console.error('Stack trace:', error.stack);
+      }
       
       setError(`Ошибка расчета: ${error.message}`);
       

--- a/supabase/functions/check-telegram-subscription/index.ts
+++ b/supabase/functions/check-telegram-subscription/index.ts
@@ -7,7 +7,20 @@ const corsHeaders = {
 }
 
 // Helper function to log to database
-async function logToDatabase(supabase: any, level: string, message: string, context: any = null, functionName: string = 'check-telegram-subscription', userId: string | null = null) {
+interface DBClient {
+  from(table: string): {
+    insert(values: Record<string, unknown>): Promise<unknown>;
+  };
+}
+
+async function logToDatabase(
+  supabase: DBClient,
+  level: string,
+  message: string,
+  context: Record<string, unknown> | null = null,
+  functionName: string = 'check-telegram-subscription',
+  userId: string | null = null,
+) {
   try {
     await supabase
       .from('system_logs')


### PR DESCRIPTION
## Summary
- remove `any` types from admin components
- refine admin log typings
- enforce stricter types in hooks and pages
- adjust supabase function typings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68695be888708333be12c101fa24541f